### PR TITLE
Commit add's a day option to the display options in RaidPal

### DIFF
--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -3,7 +3,6 @@ export const DEFAULT_PREFERENCES = {
     showTags: true,
     showProfileImg: true,
     showAmPm: true,
-    showDay: false,
     showRaidPalCreatedEvents: false,
     raidChatMessageEnabled: false,
     raidChatMessage: 'Thank you for watching! We are raiding over to {Target}, should you be left behind, please click here: https://twitch.tv/{target}',

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -3,6 +3,7 @@ export const DEFAULT_PREFERENCES = {
     showTags: true,
     showProfileImg: true,
     showAmPm: true,
+    showDay: false,
     showRaidPalCreatedEvents: false,
     raidChatMessageEnabled: false,
     raidChatMessage: 'Thank you for watching! We are raiding over to {Target}, should you be left behind, please click here: https://twitch.tv/{target}',

--- a/src/raidpal/RaidPalCustomView.js
+++ b/src/raidpal/RaidPalCustomView.js
@@ -23,7 +23,7 @@ export default function RaidPalCustomView() {
     const [selectedStreamId, setSelectedStream] = useState(null);
     const [selectedStreamUserLogin, setSelectedStreamUserLogin] = useState(null);
 
-    const { showAmPm } = useSelector(state => state.app.preferences);
+    const { showAmPm, showDay } = useSelector(state => state.app.preferences);
     const { lastError, customEventStreams: streams, customEvent } = useSelector(state => state.raidpal);
     const { login } = useSelector(state => state.session.data);
     const userCache = useSelector(state => state.users.cache);
@@ -71,6 +71,10 @@ export default function RaidPalCustomView() {
         dispatch(setPreference('showAmPm', e.target.checked));
     }, [dispatch]);
 
+    const handleToggleShowDay = useCallback((e) => {
+        dispatch(setPreference('showDay', e.target.checked));
+    }, [dispatch]);
+
     return (
         <Container>
             {lastError && (
@@ -102,6 +106,9 @@ export default function RaidPalCustomView() {
                             <div>
                                 <Form.Check type="switch" id="show-ampm" label="AM/PM" checked={showAmPm} onChange={handleToggleAmPm} />
                             </div>
+                            <div>
+                                <Form.Check type="switch" id="show-day" label="Day" checked={!!showDay} onChange={handleToggleShowDay} />
+                            </div>
                             <div className="refresh text-end flex-grow-1">
                                 <Button disabled={isStreamStatusFetching} onClick={handleRefresh}><i className="bi bi-arrow-clockwise"/></Button>
                             </div>
@@ -132,7 +139,7 @@ export default function RaidPalCustomView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format((showDay ? 'ddd ' : '') + (showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm'))}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>

--- a/src/raidpal/RaidPalCustomView.js
+++ b/src/raidpal/RaidPalCustomView.js
@@ -23,7 +23,7 @@ export default function RaidPalCustomView() {
     const [selectedStreamId, setSelectedStream] = useState(null);
     const [selectedStreamUserLogin, setSelectedStreamUserLogin] = useState(null);
 
-    const { showAmPm, showDay } = useSelector(state => state.app.preferences);
+    const { showAmPm } = useSelector(state => state.app.preferences);
     const { lastError, customEventStreams: streams, customEvent } = useSelector(state => state.raidpal);
     const { login } = useSelector(state => state.session.data);
     const userCache = useSelector(state => state.users.cache);
@@ -71,10 +71,6 @@ export default function RaidPalCustomView() {
         dispatch(setPreference('showAmPm', e.target.checked));
     }, [dispatch]);
 
-    const handleToggleShowDay = useCallback((e) => {
-        dispatch(setPreference('showDay', e.target.checked));
-    }, [dispatch]);
-
     return (
         <Container>
             {lastError && (
@@ -106,9 +102,6 @@ export default function RaidPalCustomView() {
                             <div>
                                 <Form.Check type="switch" id="show-ampm" label="AM/PM" checked={showAmPm} onChange={handleToggleAmPm} />
                             </div>
-                            <div>
-                                <Form.Check type="switch" id="show-day" label="Day" checked={!!showDay} onChange={handleToggleShowDay} />
-                            </div>
                             <div className="refresh text-end flex-grow-1">
                                 <Button disabled={isStreamStatusFetching} onClick={handleRefresh}><i className="bi bi-arrow-clockwise"/></Button>
                             </div>
@@ -139,7 +132,7 @@ export default function RaidPalCustomView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format((showDay ? 'ddd ' : '') + (showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm'))}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>

--- a/src/raidpal/RaidPalCustomView.js
+++ b/src/raidpal/RaidPalCustomView.js
@@ -132,7 +132,7 @@ export default function RaidPalCustomView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format(showAmPm ? 'ddd MMM Do, h:mma' : 'ddd MMM Do, HH:mm')}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>

--- a/src/raidpal/RaidPalView.js
+++ b/src/raidpal/RaidPalView.js
@@ -173,7 +173,7 @@ export default function RaidPalView() {
         return () => {
             clearInterval(rpRefreshInterval);
         };
-    }, [dispatch, setSelectedEventKey, handleEventChange, fetchRaidPalUser, getRaidPalData]);
+    }, [dispatch, setSelectedEventKey, handleEventChange, getRaidPalData]);
 
     const handleRefresh = useCallback(() => {
         if (selectedEvent) {

--- a/src/raidpal/RaidPalView.js
+++ b/src/raidpal/RaidPalView.js
@@ -101,7 +101,7 @@ export default function RaidPalView() {
     const [selectedStreamUserId, setSelectedStreamUserId] = useState(null);
     const [ selectedEventKey, setSelectedEventKey ] = useState(null);
 
-    const { showAmPm, showRaidPalCreatedEvents } = useSelector(state => state.app.preferences);
+    const { showAmPm, showRaidPalCreatedEvents, showDay } = useSelector(state => state.app.preferences);
     const { isFetching, lastError, /*lastUpdated,*/ data, events, streams } = useSelector(state => state.raidpal);
     const { user_id } = useSelector(state => state.session.data);
     const userCache = useSelector(state => state.users.cache);
@@ -173,7 +173,7 @@ export default function RaidPalView() {
         return () => {
             clearInterval(rpRefreshInterval);
         };
-    }, [dispatch, setSelectedEventKey, handleEventChange, getRaidPalData]);
+    }, [dispatch, setSelectedEventKey, handleEventChange, fetchRaidPalUser, getRaidPalData]);
 
     const handleRefresh = useCallback(() => {
         if (selectedEvent) {
@@ -211,6 +211,10 @@ export default function RaidPalView() {
 
     const handleToggleAmPm = useCallback((e) => {
         dispatch(setPreference('showAmPm', e.target.checked));
+    }, [dispatch]);
+
+    const handleToggleShowDay = useCallback((e) => {
+        dispatch(setPreference('showDay', e.target.checked));
     }, [dispatch]);
 
     const handleToggleShowCreatedRaidpalEvents = useCallback(e => {
@@ -279,6 +283,9 @@ export default function RaidPalView() {
                         </div>
                         <div>
                             <div>
+                              <Form.Check type="switch" id="show-day" label="Day" checked={!!showDay} onChange={handleToggleShowDay} />
+                            </div>
+                            <div>
                                 <Form.Check type="switch" id="show-ampm" label="AM/PM" checked={showAmPm} onChange={handleToggleAmPm} />
                             </div>
                             <div className="refresh text-end flex-grow-1">
@@ -310,7 +317,7 @@ export default function RaidPalView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format((showDay ? 'ddd, ' : '') + (showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm'))}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>

--- a/src/raidpal/RaidPalView.js
+++ b/src/raidpal/RaidPalView.js
@@ -310,7 +310,7 @@ export default function RaidPalView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format(showAmPm ? 'ddd MMM Do, h:mma' : 'ddd MMM Do, HH:mm')}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>

--- a/src/raidpal/RaidPalView.js
+++ b/src/raidpal/RaidPalView.js
@@ -101,7 +101,7 @@ export default function RaidPalView() {
     const [selectedStreamUserId, setSelectedStreamUserId] = useState(null);
     const [ selectedEventKey, setSelectedEventKey ] = useState(null);
 
-    const { showAmPm, showRaidPalCreatedEvents, showDay } = useSelector(state => state.app.preferences);
+    const { showAmPm, showRaidPalCreatedEvents } = useSelector(state => state.app.preferences);
     const { isFetching, lastError, /*lastUpdated,*/ data, events, streams } = useSelector(state => state.raidpal);
     const { user_id } = useSelector(state => state.session.data);
     const userCache = useSelector(state => state.users.cache);
@@ -213,10 +213,6 @@ export default function RaidPalView() {
         dispatch(setPreference('showAmPm', e.target.checked));
     }, [dispatch]);
 
-    const handleToggleShowDay = useCallback((e) => {
-        dispatch(setPreference('showDay', e.target.checked));
-    }, [dispatch]);
-
     const handleToggleShowCreatedRaidpalEvents = useCallback(e => {
         dispatch(setPreference('showRaidPalCreatedEvents', e.target.checked));
     }, [dispatch]);
@@ -283,9 +279,6 @@ export default function RaidPalView() {
                         </div>
                         <div>
                             <div>
-                              <Form.Check type="switch" id="show-day" label="Day" checked={!!showDay} onChange={handleToggleShowDay} />
-                            </div>
-                            <div>
                                 <Form.Check type="switch" id="show-ampm" label="AM/PM" checked={showAmPm} onChange={handleToggleAmPm} />
                             </div>
                             <div className="refresh text-end flex-grow-1">
@@ -317,7 +310,7 @@ export default function RaidPalView() {
                                             {slot.slot_occupied ? slot.broadcaster_display_name : <em>slot not occupied</em>}
                                         </div>
                                         <div className="timing">
-                                            <span>{Moment(slot.starttime).format((showDay ? 'ddd, ' : '') + (showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm'))}</span>{' – '}
+                                            <span>{Moment(slot.starttime).format(showAmPm ? 'MMM Do, h:mma' : 'MMM Do, HH:mm')}</span>{' – '}
                                             <span>{Moment(slot.endtime).format(showAmPm ? 'h:mma' : 'HH:mm')}</span>
                                         </div>
                                     </div>


### PR DESCRIPTION
Adds an optional “Day” toggle to RaidPal to show weekday abbreviations next to times. This improves quick scanning and reduces ambiguity for cross‑timezone or overnight slots.